### PR TITLE
Add INSPIRE keywords with anchor

### DIFF
--- a/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -442,6 +442,11 @@
         <for name="cit:CI_Individual"/>
         <for name="cit:CI_Organisation"/>
       </flatModeExceptions>
+      <thesaurusList>
+        <thesaurus key="external.theme.httpinspireeceuropaeutheme-theme" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
+        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
+        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistPriorityDataset-PriorityDataset" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
+      </thesaurusList>
     </view>
 
 
@@ -539,6 +544,11 @@
         <section xpath="/mdb:MD_Metadata/mdb:applicationSchemaInfo" or="applicationSchemaInfo"
                  in="/mdb:MD_Metadata"/>
       </tab>
+      <thesaurusList>
+        <thesaurus key="external.theme.httpinspireeceuropaeutheme-theme" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
+        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
+        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistPriorityDataset-PriorityDataset" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
+      </thesaurusList>
     </view>
     <view name="xml">
       <sidePanel>


### PR DESCRIPTION
This will make the editor use anchor mode by default when adding a keyword from INSPIRE thesauri.