### PR TITLE
Enable display of bounding polygons in default view

### DIFF
--- a/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
+++ b/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
@@ -358,6 +358,10 @@
         </xsl:for-each>
       </xsl:for-each>
 
+      <xsl:if test="*/gex:EX_Extent/*/gex:EX_BoundingPolygon">
+        <Field name="boundingPolygon" string="y" store="true" index="false"/>
+      </xsl:if>
+
 
       <xsl:for-each select="//mri:MD_Keywords">
         <xsl:variable name="thesaurusTitle"


### PR DESCRIPTION
Display bounding polygon in default 19115-3:2018 view after https://github.com/geonetwork/core-geonetwork/pull/4491 is merged.

![image](https://user-images.githubusercontent.com/1860215/75929865-8b7cc680-5ec5-11ea-9d09-deaa5dae5ce5.png)
