### PR TITLE
Removing last online resource will leave an empty mrd:transferOptions

### DIFF
--- a/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -598,11 +598,12 @@
     </xsl:choose>
   </xsl:template>
 
-  <!-- Remove empty DQ elements. -->
+
+  <!-- Remove empty DQ elements, empty transfer options. -->
   <xsl:template match="mdb:dataQualityInfo[count(*) = 0]"/>
+  <xsl:template match="mrd:transferOptions[mrd:MD_DigitalTransferOptions/count(*) = 0]"/>
 
   <!-- copy everything else as is -->
-
   <xsl:template match="@*|node()">
     <xsl:copy copy-namespaces="no">
       <xsl:apply-templates select="@*|node()"/>

--- a/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -10,6 +10,7 @@
   xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
   xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
   xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+  xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
   xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0"
   xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
Record is then invalid from an XSD point of view.
Add cleanup in update fixed info.