### PR TITLE
change cloudcoverpercentage label description

### DIFF
--- a/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
+++ b/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
@@ -2153,7 +2153,8 @@
     <label>Classification system</label>
     <description>Name of the classification system</description>
   </element>
-  <element name="mri:cloudCoverPercentage" id="248.0">
+<!--  <element name="mri:cloudCoverPercentage" id="248.0"> -->
+        <element name="mrc:cloudCoverPercentage" id="248.0">
     <label>Cloud cover percentage</label>
     <description>Area of the dataset obscured by clouds, expressed as a
       percentage of the

--- a/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
+++ b/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
@@ -2153,8 +2153,7 @@
     <label>Classification system</label>
     <description>Name of the classification system</description>
   </element>
-<!--  <element name="mri:cloudCoverPercentage" id="248.0"> -->
-        <element name="mrc:cloudCoverPercentage" id="248.0">
+  <element name="mrc:cloudCoverPercentage" id="248.0">
     <label>Cloud cover percentage</label>
     <description>Area of the dataset obscured by clouds, expressed as a
       percentage of the


### PR DESCRIPTION
Hi,
when I try to validate metadata I got this error:

gn-fn-metadata:getLabel | missing translation in schema iso19115-3.2018 for mrc:cloudCoverPercentage.

looking here it seems that we have the label defined as 
mri:cloudCoverPercentage

in my opinion, it should be
mrc:cloudCoverPercentage

could you please check?

Ps if this is the case, it should be checked also the following labels:
mrc:compressionGenerationQuantity.
gml:DerivedUnit.
gml:ConventionalUnit