### PR TITLE
Parent reference / Also support associated resources

### DIFF
--- a/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
+++ b/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
@@ -43,6 +43,10 @@
   <!-- Enable INSPIRE or not -->
   <xsl:param name="inspire">false</xsl:param>
 
+  <!-- Parent may be encoded using an associatedResource.
+  Define which association type should be considered as parent. -->
+  <xsl:variable name="parentAssociatedResourceType" select="'partOfSeamlessDatabase'"/>
+
   <xsl:variable name="df">[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01]</xsl:variable>
 
   <!-- If identification citation dates
@@ -539,6 +543,11 @@
                               else mri:metadataReference/cit:CI_Citation/cit:identifier/mcc:MD_Identifier/mcc:code/gco:CharacterString"/>
         <xsl:if test="$code != ''">
           <xsl:variable name="associationType" select="mri:associationType/mri:DS_AssociationTypeCode/@codeListValue"/>
+
+          <xsl:if test="$associationType = $parentAssociatedResourceType">
+            <Field name="parentUuid" string="{string($code)}" store="true" index="true"/>
+          </xsl:if>
+
           <xsl:variable name="initiativeType" select="mri:initiativeType/mri:DS_InitiativeTypeCode/@codeListValue"/>
           <Field name="agg_{$associationType}_{$initiativeType}" string="{$code}" store="false" index="true"/>
           <Field name="agg_{$associationType}_with_initiative" string="{$initiativeType}" store="false" index="true"/>
@@ -1034,7 +1043,7 @@
           <Field name="crs" string="{$crs}" store="true" index="true"/>
           <Field name="crsCode" string="{mcc:code/gco:CharacterString}" store="true" index="true"/>
         </xsl:if>
-        
+
         <xsl:variable name="crsDetails">
           {
           "code": "<xsl:value-of select="mcc:code/*/text()"/>",

--- a/src/main/resources/config-spring-geonetwork.xml
+++ b/src/main/resources/config-spring-geonetwork.xml
@@ -12,6 +12,22 @@
         <value>mdb:identificationInfo/*/mri:citation/*/cit:title/*/lan:textGroup/lan:LocalisedCharacterString</value>
       </util:list>
     </property>
+    <!--
+    When using a custom parent relation mechanism, the editor needs to be
+    updated in order to create the proper link (instead of the default parentMetadata mode).
+    See web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+      <li data-ng-show="gnCurrentEdit.metadata['geonet:info'].schema == 'iso19115-3.2018'
+          && !gnCurrentEdit.isService
+          && gnCurrentEdit.metadata.type.indexOf('series') === -1">
+            <a href=""
+               data-ng-click="onlinesrcService.onOpenPopup('sibling', {associationType: 'partOfSeamlessDatabase', initiativeType: 'collection'})">
+              <i class="fa gn-icon-sibling"></i>
+              <i class="icon-external-link"></i>&nbsp;
+              <span data-translate="">linkToParent</span>
+            </a>
+          </li>
+    -->
+    <property name="parentAssociatedResourceType" value="partOfSeamlessDatabase"/>
     <property name="elementsToProcess">
       <util:list value-type="java.lang.String">
         <value>gco:CharacterString</value>


### PR DESCRIPTION
Some (most?) of the users of ISO19115-3 are using associated resources to make link to parent metadata. Mainly using an association type `partOfSeamlessDatabase`.

Add the possibility to consider those references as a parent/child relation, ie.:
* exclude them from associated
* add browsing to "brothers & sisters".

Encoding used is:
```xml
 <mri:associatedResource>
    <mri:MD_AssociatedResource>
       <mri:associationType>
          <mri:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode"
                                      codeListValue="partOfSeamlessDatabase"/>
       </mri:associationType>
       <mri:metadataReference uuidref="1216db12-7dd2-4c57-ade7-beea76ae5f61"/>
    </mri:MD_AssociatedResource>
 </mri:associatedResource>
 <mri:associatedResource>
    <mri:MD_AssociatedResource>
       <mri:associationType>
          <mri:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode"
                                      codeListValue="source"/>
       </mri:associationType>
       <mri:initiativeType>
          <mri:DS_InitiativeTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_InitiativeTypeCode"
                                     codeListValue="collection"/>
       </mri:initiativeType>
       <mri:metadataReference uuidref="6a162807-0315-4ff6-8953-f63d81b8f3a1"/>
    </mri:MD_AssociatedResource>
 </mri:associatedResource>
```
Then parents could be a `mdb:parentMetadata` or `mri:associatedResource` with association type set to `partOfSeamlessDatabase` (the value is configuration of the plugin).

![image](https://user-images.githubusercontent.com/1701393/79577073-6d110a00-80c4-11ea-87ac-e2f53acecf4b.png)

@jonescc not sure if this could be enabled by default ? Any guidelines on this in ANZLIC ?

