### PR TITLE
Editor / Polygon / Fix validation error on srsName and id attributes.

### DIFF
--- a/src/main/plugin/iso19115-3.2018/update-fixed-info-subtemplate.xsl
+++ b/src/main/plugin/iso19115-3.2018/update-fixed-info-subtemplate.xsl
@@ -132,6 +132,7 @@
     </xsl:if>
   </xsl:template>
 
+  <xsl:template match="gml:LinearRing/@srsName"/>
 
   <xsl:template match="@*|node()">
     <xsl:copy>

--- a/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -276,10 +276,10 @@
                        gml:LineString[not(@gml:id) or not(@srsName)]">
     <xsl:copy>
       <xsl:attribute name="gml:id">
-        <xsl:value-of select="generate-id(.)"/>
+        <xsl:value-of select="if (@gml:id != '') then @gml:id else generate-id(.)"/>
       </xsl:attribute>
       <xsl:attribute name="srsName">
-        <xsl:text>urn:ogc:def:crs:EPSG:6.6:4326</xsl:text>
+        <xsl:value-of select="if (@srsName != '') then @srsName else 'urn:ogc:def:crs:EPSG:6.6:4326'"/>
       </xsl:attribute>
       <xsl:copy-of select="@*"/>
       <xsl:apply-templates select="*"/>

--- a/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -255,6 +255,8 @@
 
   <!-- Fix srsName attribute generate CRS:84 (EPSG:4326 with long/lat
     ordering) by default -->
+  <xsl:template match="gml:LinearRing/@srsName"/>
+
   <xsl:template match="@srsName">
     <xsl:choose>
       <xsl:when test="normalize-space(.)=''">
@@ -269,9 +271,9 @@
   </xsl:template>
 
   <!-- Add required gml attributes if missing -->
-  <xsl:template match="gml:Polygon[not(@gml:id) and not(@srsName)]|
-                       gml:MultiSurface[not(@gml:id) and not(@srsName)]|
-                       gml:LineString[not(@gml:id) and not(@srsName)]">
+  <xsl:template match="gml:Polygon[not(@gml:id) or not(@srsName)]|
+                       gml:MultiSurface[not(@gml:id) or not(@srsName)]|
+                       gml:LineString[not(@gml:id) or not(@srsName)]">
     <xsl:copy>
       <xsl:attribute name="gml:id">
         <xsl:value-of select="generate-id(.)"/>

--- a/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -281,7 +281,7 @@
       <xsl:attribute name="srsName">
         <xsl:value-of select="if (@srsName != '') then @srsName else 'urn:ogc:def:crs:EPSG:6.6:4326'"/>
       </xsl:attribute>
-      <xsl:copy-of select="@*"/>
+      <xsl:copy-of select="@*[name() != 'srsName' and local-name() != 'id' and name() != 'xmlns']"/>
       <xsl:apply-templates select="*"/>
     </xsl:copy>
   </xsl:template>


### PR DESCRIPTION
When adding bounding polygon, issues are reported on validation.

![image](https://user-images.githubusercontent.com/1701393/85522811-6d6adb80-b606-11ea-8c02-726e4d61f55e.png)


Since OL6 update, an srsName is added to LinearRing in GML3.2.0.

![image](https://user-images.githubusercontent.com/1701393/85522835-722f8f80-b606-11ea-87c6-a8056e1ae5b9.png)


GML2 OL format was not. See
 https://github.com/openlayers/openlayers/blame/v6.3.1/src/ol/format/GML2.js#L228
.
GML3 does https://github.com/openlayers/openlayers/blob/v6.3.1/src/ol/format/GML3.js#L503

From the XSD, this attribute should probably not be added https://schemas.wmo.int/wmdr/1.0RC6/documentation/schemadoc/schemas/geometryBasic2d_xsd/elements/LinearRing.html.

Workaround that issue by updating `LinearRing` in `update-fixed-info.xsl`.