### PR TITLE
Indexing / Do not index translations if record has no language defined

### DIFF
--- a/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -132,10 +132,12 @@
                               @codeListValue[normalize-space(.) != '']"/>
 
     <xsl:variable name="allLanguages">
-      <lang id="default" value="{$mainLanguage}"/>
-      <xsl:for-each select="$otherLanguages">
-        <lang id="{../../../@id}" value="{.}"/>
-      </xsl:for-each>
+      <xsl:if test="$mainLanguage != ''">
+        <lang id="default" value="{$mainLanguage}"/>
+        <xsl:for-each select="$otherLanguages">
+          <lang id="{../../../@id}" value="{.}"/>
+        </xsl:for-each>
+      </xsl:if>
     </xsl:variable>
 
     <!-- Record is dataset if no hierarchyLevel -->


### PR DESCRIPTION
If main language was not defined, wrong facet translation were returned (lower case and wrong field name)

```json

mainLanguage: "",
codelist_resourceScope: "service",
codelist_resourceScope_text: "service",
codelist_resourceScope_text_lang: "service",
```
now
```

mainLanguage: "fre",
codelist_resourceScope: "service",
codelist_resourceScope_text: "Service",
codelist_resourceScope_text_langfre: "Service",
```