### PR TITLE
Propagate isDisabled parameter through boxed elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 target
 doc/en/iso19115-3.2018.rst
 doc/fr/iso19115-3.2018.rst
+.classpath
+.project
+.settings

--- a/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-contact.xsl
+++ b/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-contact.xsl
@@ -35,10 +35,12 @@
   <xsl:template mode="mode-iso19115-3.2018" match="*[cit:CI_Telephone]" priority="2000">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="isDisabled" required="no" />
 
     <xsl:apply-templates mode="mode-iso19115-3.2018" select="*/cit:*">
       <xsl:with-param name="schema" select="$schema"/>
       <xsl:with-param name="labels" select="$labels"/>
+      <xsl:with-param name="isDisabled" select="$isDisabled" />
     </xsl:apply-templates>
   </xsl:template>
 
@@ -51,6 +53,9 @@
                 match="cit:number[parent::node()/name() = 'cit:CI_Telephone']">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="isDisabled" required="no"/>
+    
+
 
     <xsl:variable name="labelConfig"
                   select="gn-fn-metadata:getLabel($schema, name(), $labels)"/>
@@ -73,7 +78,7 @@
         <xsl:call-template name="render-codelist-as-select">
           <xsl:with-param name="listOfValues" select="$codelist"/>
           <xsl:with-param name="lang" select="$lang"/>
-          <xsl:with-param name="isDisabled" select="ancestor-or-self::node()[@xlink:href]"/>
+          <xsl:with-param name="isDisabled" select="$isDisabled or ancestor-or-self::node()[@xlink:href]"/>
           <xsl:with-param name="elementRef" select="../cit:numberType/cit:CI_TelephoneTypeCode/gn:element/@ref"/>
           <xsl:with-param name="isRequired" select="true()"/>
           <xsl:with-param name="hidden" select="false()"/>
@@ -93,7 +98,7 @@
                type="tel"
                name="{concat('_', gco:CharacterString/gn:element/@ref)}"
                value="{normalize-space(gco:CharacterString)}">
-          <xsl:if test="ancestor-or-self::node()[@xlink:href]">
+          <xsl:if test="$isDisabled or ancestor-or-self::node()[@xlink:href]">
             <xsl:attribute name="disabled" select="'disabled'"/>
           </xsl:if>
         </input>
@@ -112,10 +117,12 @@
         </div>
       </div>
       <div class="col-sm-1 gn-control">
-        <xsl:call-template name="render-form-field-control-remove">
-          <xsl:with-param name="editInfo" select="../gn:element"/>
-          <xsl:with-param name="parentEditInfo" select="../../gn:element"/>
-        </xsl:call-template>
+        <xsl:if test="not($isDisabled)">
+          <xsl:call-template name="render-form-field-control-remove">
+            <xsl:with-param name="editInfo" select="../gn:element"/>
+            <xsl:with-param name="parentEditInfo" select="../../gn:element"/>
+          </xsl:call-template>
+        </xsl:if>
       </div>
     </div>
   </xsl:template>

--- a/src/main/plugin/iso19115-3.2018/layout/layout.xsl
+++ b/src/main/plugin/iso19115-3.2018/layout/layout.xsl
@@ -43,11 +43,13 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="refToDelete" required="no"/>
+    <xsl:param name="isDisabled" required="no"/>
 
     <xsl:apply-templates mode="mode-iso19115-3.2018" select="*|@*">
       <xsl:with-param name="schema" select="$schema"/>
       <xsl:with-param name="labels" select="$labels"/>
       <xsl:with-param name="refToDelete" select="$refToDelete"/>
+      <xsl:with-param name="isDisabled" select="$isDisabled"/>
     </xsl:apply-templates>
   </xsl:template>
 
@@ -145,6 +147,7 @@
                         not(gco:CharacterString)]">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="isDisabled" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
@@ -174,14 +177,16 @@
       <xsl:with-param name="errors" select="$errors"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
+      <xsl:with-param name="isDisabled" select="$isDisabled"/>
       <xsl:with-param name="attributesSnippet" select="$attributes"/>
       <xsl:with-param name="subTreeSnippet">
         <!-- Process child of those element. Propagate schema
-        and labels to all subchilds (eg. needed like iso19110 elements
+        and labels to all subchildren (eg. needed like iso19110 elements
         contains gmd:* child. -->
         <xsl:apply-templates mode="mode-iso19115-3.2018" select="*">
           <xsl:with-param name="schema" select="$schema"/>
           <xsl:with-param name="labels" select="$labels"/>
+          <xsl:with-param name="isDisabled" select="$isDisabled"/>
         </xsl:apply-templates>
       </xsl:with-param>
     </xsl:call-template>
@@ -484,6 +489,7 @@
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="codelists" select="$codelists" required="no"/>
     <xsl:param name="overrideLabel" select="''" required="no"/>
+    <xsl:param name="isDisabled" required="no"/>
 
     <xsl:variable name="elementName" select="name()"/>
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
@@ -516,6 +522,7 @@
       <xsl:with-param name="listOfValues"
                       select="gn-fn-metadata:getCodeListValues($schema, name(*[@codeListValue]), $codelists, .)"/>
       <xsl:with-param name="isFirst" select="count(preceding-sibling::*[name() = $elementName]) = 0"/>
+      <xsl:with-param name="isDisabled" select="$isDisabled or count(ancestor-or-self::node()[@xlink:href]) > 0"/>
     </xsl:call-template>
   </xsl:template>
 


### PR DESCRIPTION
With this change a user can define a boxed element as disabled. This commit propagates that parameter through these templates to render the fields as readonly.
For example, you could use it to set the `/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:citedResponsibleParty` children fields as not editable because you want the users to select the contact from a search contact widget.

![image](https://user-images.githubusercontent.com/826920/87729162-fff53980-c7c4-11ea-9519-1f6aa6942d4c.png)


Related to ga-gn/core-geonetwork#19.