### PR TITLE
Fixes #78 - display gml:identifer/gml:name elements in full view (mrc:units)

### DIFF
--- a/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -386,6 +386,7 @@
                        *[gml:beginPosition != '']|*[gml:endPosition != '']|
                        *[gco:Date != '']|*[gco:DateTime != '']|*[gco:TM_PeriodDuration != '']|
                        *[*/@codeListValue]|*[@codeListValue]|
+                       gml:identifier[. != '']|gml:name[. != '']|
                        gml:description[. != '']|gml:timePosition[. != '']|
                        gml:beginPosition[. != '']|gml:endPosition[. != '']"
                 priority="500">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1860215/88659842-0bc3f280-d119-11ea-9d72-f43e9890076a.png)
