### PR TITLE
Addresses #87 - Only include details from the first contactInfo element

### DIFF
--- a/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
+++ b/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
@@ -1092,20 +1092,20 @@
 
     <xsl:variable name="uuid" select="@uuid"/>
     <xsl:variable name="role" select="../../cit:role/*/@codeListValue"/>
-    <xsl:variable name="email" select="cit:contactInfo/cit:CI_Contact/
+    <xsl:variable name="email" select="cit:contactInfo[1]/cit:CI_Contact/
                              cit:address/cit:CI_Address/
-                             cit:electronicMailAddress/gco:CharacterString|
-                 cit:individual//cit:contactInfo/cit:CI_Contact/
+                             cit:electronicMailAddress/gco:CharacterString[normalize-space()!='']|
+                 cit:individual//cit:contactInfo[1]/cit:CI_Contact/
                                 cit:address/cit:CI_Address/
-                                cit:electronicMailAddress/gco:CharacterString"/>
+                                cit:electronicMailAddress/gco:CharacterString[normalize-space()!='']"/>
     <xsl:variable name="roleTranslation" select="util:getCodelistTranslation('cit:CI_RoleCode', string($role), string($lang))"/>
     <xsl:variable name="logo" select="cit:logo/mcc:MD_BrowseGraphic/mcc:fileName/gco:CharacterString"/>
-    <xsl:variable name="website" select=".//cit:onlineResource/*/cit:linkage/gco:CharacterString"/>
+    <xsl:variable name="website" select="cit:contactInfo[1]//cit:onlineResource[1]/*/cit:linkage/gco:CharacterString"/>
     <xsl:variable name="phones"
-                  select=".//cit:contactInfo/cit:CI_Contact/cit:phone/*/cit:number/gco:CharacterString"/>
+                  select="cit:contactInfo[1]/cit:CI_Contact/cit:phone/*/cit:number/gco:CharacterString"/>
     <!--<xsl:variable name="phones"
                   select="cit:contactInfo/cit:CI_Contact/cit:phone/concat(*/cit:numberType/*/@codeListValue, ':', */cit:number/gco:CharacterString)"/>-->
-    <xsl:variable name="address" select="string-join(cit:contactInfo/*/cit:address/*/(
+    <xsl:variable name="address" select="string-join(cit:contactInfo[1]/*/cit:address/*/(
                                           cit:deliveryPoint|cit:postalCode|cit:city|
                                           cit:administrativeArea|cit:country)/gco:CharacterString/text(), ', ')"/>
     <xsl:variable name="individualNames" select="cit:individual//cit:name/gco:CharacterString"/>


### PR DESCRIPTION
Only include details from the first contactInfo element when indexing responsible party's to more align with the way 19139 records are indexed until gnMetadataContact is reworked to handle 19115-3:2018 responsible parties
Difficult to handle all possible combinations until that rework is done.  This at least allows records with multiple websites to be indexed and makes the display less confusing.

Emails are tricky because they are currently displayed against the individuals so have left that as it is.

Ideally organisation contact details would be displayed under the organisation (all of them) - individuals would be displayed along with their relevant contact details under there.  

![image](https://user-images.githubusercontent.com/1860215/91528390-fe359e80-e94a-11ea-9eb9-b0ad423ec373.png)
